### PR TITLE
Xcode 8: Move `CodeSigning` requirement and inclusion to `AppTarget` & `ExtensionTarget`.

### DIFF
--- a/Targets/Apps/AppTarget.xcconfig
+++ b/Targets/Apps/AppTarget.xcconfig
@@ -5,6 +5,8 @@
 //
 
 #include "../Target.xcconfig"
+#include "../../CodeSigning.xcconfig"
 
+CODE_SIGNING_REQUIRED = YES
 GCC_DYNAMIC_NO_PIC = NO
 SKIP_INSTALL = NO

--- a/Targets/Extensions/ExtensionTarget.xcconfig
+++ b/Targets/Extensions/ExtensionTarget.xcconfig
@@ -5,3 +5,6 @@
 //
 
 #include "../Target.xcconfig"
+#include "../../CodeSigning.xcconfig"
+
+CODE_SIGNING_REQUIRED = YES

--- a/Targets/Target.xcconfig
+++ b/Targets/Target.xcconfig
@@ -5,13 +5,14 @@
 //
 
 #include "../Architectures.xcconfig"
-#include "../CodeSigning.xcconfig"
 #include "../CompilerFeatures.xcconfig"
 #include "../CompilerWarnings.xcconfig"
 
 DEBUG_INFORMATION_FORMAT_Debug = dwarf
 DEBUG_INFORMATION_FORMAT_Release = dwarf-with-dsym
 DEBUG_INFORMATION_FORMAT = $(DEBUG_INFORMATION_FORMAT_$(CONFIGURATION))
+
+CODE_SIGNING_REQUIRED = NO
 
 ALWAYS_SEARCH_USER_PATHS = NO
 


### PR DESCRIPTION
Code signing will usually still be required at the point of embedding frameworks/static-libraries/extensions in a bundle.
